### PR TITLE
Added correct interaction type to DoInteractionEvent function

### DIFF
--- a/nmspy/data/types.py
+++ b/nmspy/data/types.py
@@ -2368,7 +2368,7 @@ class cGcInteractionComponent(Structure):
     def DoInteractionEvent(
         self,
         this: "_Pointer[cGcInteractionComponent]",
-        leEvent: Annotated[int, c_uint32],  # eInteractionEvent
+        leEvent: c_enum32[enums.cGcInteractionType],
     ): ...
 
     @function_hook("40 53 48 83 EC ? 48 8B D9 48 8B 0D ? ? ? ? 8B 93")


### PR DESCRIPTION
Changed the parameter type in DoInteractionEvent to the proper enum instead of a generic c_uint32. I made sure that the enum ``cGcInteractionType`` is already present in ``external_enums.py`` and has been exported in ``nmspy/data/enums/__init__.py``, so it looks like there is nothing else to do for this small addition